### PR TITLE
Enable MPICH RDMA for CUDA

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -4,11 +4,14 @@
 # environments for the dycore and the Fortran parts. Namely, the following
 # functions must be defined in this file:
 
+module swap PrgEnv-cray PrgEnv-gnu
 module load daint-gpu
 module load cray-python
+module load cray-mpich
 module load Boost
 module load cudatoolkit
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+export MPICH_RDMA_ENABLED_CUDA=1
 

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -4,8 +4,8 @@
 # environments for the dycore and the Fortran parts. Namely, the following
 # functions must be defined in this file:
 
-module swap PrgEnv-cray PrgEnv-gnu
 module load daint-gpu
+module swap PrgEnv-cray PrgEnv-gnu
 module load cray-python
 module load cray-mpich
 module load Boost


### PR DESCRIPTION
This PR makes the following changes to the Daint environment:
1. Load GCC compiler environment rather than Cray default (clang).
2. Load the `cray-mpich` module.
3. Set `MPICH_RDMA_ENABLED_CUDA` to 1.