### PR TITLE
adding a retry to the scheduler tools launch_job

### DIFF
--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -47,15 +47,17 @@ function launch_job {
 
   # submit SLURM job
   local res=$(sbatch ${script} 2>&1)
-  if [ $? -ne 0 ] ; then
-      exitError 7204 ${LINENO} "problem submitting SLURM batch job"
-  fi
+  status=$?
   if [[ $res == *"QOSMaxSubmitJobPerUserLimit"* ]]; then
       echo "Partition chosen has to many jobs from us already, trying again with the normal partition."
       sed -i 's|--partition=.*|--partition=normal|g' ${script}
       res=`sbatch ${script}`
       if [ $? -ne 0 ] ; then
 	  exitError 7205 ${LINENO} "problem re-submitting SLURM batch job in normal queue"
+      fi
+  else
+      if [ $? -ne 0 ] ; then
+	  exitError 7204 ${LINENO} "problem submitting SLURM batch job"
       fi
   fi
   echo "${res}" | grep "^Submitted batch job [0-9][0-9]*$" || exitError 7206 ${LINENO} "problem determining job ID of SLURM job"

--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -56,7 +56,7 @@ function launch_job {
 	  exitError 7205 ${LINENO} "problem re-submitting SLURM batch job in normal queue"
       fi
   else
-      if [ $? -ne 0 ] ; then
+      if [ $status -ne 0 ] ; then
 	  exitError 7204 ${LINENO} "problem submitting SLURM batch job"
       fi
   fi


### PR DESCRIPTION
We are using the debug queue on cscsc now for the 54 ranks parallel numpy tests and the gt backend fv_dynamics tests. When there is more than one or two PRs trying to test now, we often hit the QOSMaxSubmitJobPerUserLimit there, failing the whole job. We could always submit to 'normal', but this will make everything take a long time when the queue is busy and we are just trying to run some small ci jobs (that are too large for the cscsci queue, multinode). 
Adding a feature to the launch_job that will detect when the limit is hit, and resubmit to the normal queue, so we can still run some jobs in debug.... 