### PR TITLE
Revert back to gcc/8.1.0 and cuda/10.2 on Daint

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -6,17 +6,14 @@
 
 module load daint-gpu
 module swap PrgEnv-cray PrgEnv-gnu
-module load cray-python
-module load cray-mpich
-module load Boost
-module load cudatoolkit
-module load graphviz
+module load cray-python/3.8.5.0
+module load cray-mpich/7.7.16
+module load Boost/1.70.0-CrayGNU-20.11-python3
+module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
+module load graphviz/2.44.0
 
 # since gridtools does not play nice with gcc 8.3 we switch to 8.1
 module switch gcc gcc/8.1.0
-
-# we need to work with CUDA 10.2
-module switch cudatoolkit cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -11,13 +11,17 @@ module load cray-mpich
 module load Boost
 module load cudatoolkit
 module load graphviz
+
+# since gridtools does not play nice with gcc 8.3 we switch to 8.1
+module switch gcc gcc/8.1.0
+
+# we need to work with CUDA 10.2
+module switch cudatoolkit cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
+
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 export MPICH_RDMA_ENABLED_CUDA=1
-
-# since gridtools does not play nice with gcc 8.3 we switch to 8.1
-module switch gcc/8.3.0 gcc/8.1.0
 
 # the eve toolchain requires a clang-format executable, we point it to the right place
 export CLANG_FORMAT_EXECUTABLE=/project/s1053/install/venv/vcm_1.0/bin/clang-format


### PR DESCRIPTION
This PR fixes our gcc version to 8.1.0 and our CUDA version to 10.2. Since the upgrade, the defaults have changed and our module environment was no longer functional (or simply picked up the new default versions).