### PR TITLE
Update to GCC/9.3 and CUDA/11.0

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -6,19 +6,14 @@
 
 module load daint-gpu
 module swap PrgEnv-cray PrgEnv-gnu
+module load cdt-cuda/20.11
+module load cudatoolkit/11.0.2_3.33-7.0.2.1_3.1__g1ba0366
 module load cray-python/3.8.5.0
-module load cray-mpich/7.7.16
 module load Boost/1.70.0-CrayGNU-20.11-python3
-module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
+module switch gcc gcc/9.3.0
 module load graphviz/2.44.0
-
-# since gridtools does not play nice with gcc 8.3 we switch to 8.1
-module switch gcc gcc/8.1.0
 
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 export MPICH_RDMA_ENABLED_CUDA=1
-
-# the eve toolchain requires a clang-format executable, we point it to the right place
-export CLANG_FORMAT_EXECUTABLE=/project/s1053/install/venv/vcm_1.0/bin/clang-format


### PR DESCRIPTION
This PR will update to the newest programming environment, updating from GCC/8.1 to GCC/9.3 and from CUDA/10.2 to CUDA/11.0. In detail, it will move from the current environment...
```
  1) modules/3.2.11.4(default)
  2) cge/3.2.1463_r03f4dfb_fe3.3.0_2019062614
  3) craype-network-aries
  4) gcc/8.1.0
  5) craype/2.7.3(default)
  6) cray-mpich/7.7.16(default)
  7) slurm/20.11.4-2
  8) craype-haswell
  9) xalt/2.8.10
 10) daint-gpu
 11) cray-libsci/20.09.1(default)
 12) udreg/2.3.2-7.0.2.1_2.27__g8175d3d.ari
 13) ugni/6.0.14.0-7.0.2.1_3.46__ge78e5b0.ari
 14) pmi/5.0.17(default)
 15) dmapp/7.1.1-7.0.2.1_2.52__g38cf134.ari
 16) gni-headers/5.0.12.0-7.0.2.1_2.10__g3b1768f.ari
 17) xpmem/2.2.20-7.0.2.1_2.45__g87eb960.ari
 18) job/2.2.4-7.0.2.1_2.49__g36b56f4.ari
 19) dvs/2.12_2.2.170-7.0.2.1_6.10__gfe7b137d
 20) alps/6.6.59-7.0.2.1_3.39__g872a8d62.ari
 21) rca/2.2.20-7.0.2.1_2.55__g8e3fb5b.ari
 22) atp/3.8.1(default)
 23) perftools-base/20.10.0(default)
 24) PrgEnv-gnu/6.0.9
 25) cray-python/3.8.5.0(default)
 26) cdt-cuda/20.11
 27) CrayGNU/.20.11
 28) bzip2/.1.0.6-CrayGNU-20.11
 29) zlib/.1.2.11-CrayGNU-20.11
 30) Boost/1.70.0-CrayGNU-20.11-python3
 31) cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 32) graphviz/2.44.0
```
...to the following environment...
```
  1) modules/3.2.11.4(default)
  2) cge/3.2.1463_r03f4dfb_fe3.3.0_2019062614
  3) craype-network-aries
  4) gcc/9.3.0
  5) craype/2.7.3(default)
  6) cray-mpich/7.7.16(default)
  7) slurm/20.11.4-2
  8) craype-haswell
  9) xalt/2.8.10
 10) daint-gpu
 11) cray-libsci/20.09.1(default)
 12) udreg/2.3.2-7.0.2.1_2.27__g8175d3d.ari
 13) ugni/6.0.14.0-7.0.2.1_3.46__ge78e5b0.ari
 14) pmi/5.0.17(default)
 15) dmapp/7.1.1-7.0.2.1_2.52__g38cf134.ari
 16) gni-headers/5.0.12.0-7.0.2.1_2.10__g3b1768f.ari
 17) xpmem/2.2.20-7.0.2.1_2.45__g87eb960.ari
 18) job/2.2.4-7.0.2.1_2.49__g36b56f4.ari
 19) dvs/2.12_2.2.170-7.0.2.1_6.10__gfe7b137d
 20) alps/6.6.59-7.0.2.1_3.39__g872a8d62.ari
 21) rca/2.2.20-7.0.2.1_2.55__g8e3fb5b.ari
 22) perftools-base/20.10.0(default)
 23) PrgEnv-gnu/6.0.9
 24) atp/3.8.1(default)
 25) cudatoolkit/11.0.2_3.33-7.0.2.1_3.1__g1ba0366
 26) cray-python/3.8.5.0(default)
 27) cdt-cuda/20.11
 28) CrayGNU/.20.11
 29) bzip2/.1.0.6-CrayGNU-20.11
 30) zlib/.1.2.11-CrayGNU-20.11
 31) Boost/1.70.0-CrayGNU-20.11-python3
 32) graphviz/2.44.0
```