### PR TITLE
Turn on MPICH APE's for GPU

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -18,7 +18,13 @@ module switch gcc gcc/8.1.0
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+
+# Setup RDMA for GPU. Set PIPE size to 256 (# of messages allowed in flight)
+# Turn as-soon-as-possible transfer (NEMESIS_ASYNC_PROGRESS) on
 export MPICH_RDMA_ENABLED_CUDA=1
+export MPICH_G2G_PIPELINE=256
+export MPICH_NEMESIS_ASYNC_PROGRESS=1
+export MPICH_MAX_THREAD_SAFETY=multiple
 
 # the eve toolchain requires a clang-format executable, we point it to the right place
 export CLANG_FORMAT_EXECUTABLE=/project/s1053/install/venv/vcm_1.0/bin/clang-format


### PR DESCRIPTION
This PR will turn on the APE engine of MPICH and allow for as-soon-as-possible transfer to happen through the GPU RDMA

See: https://www.olcf.ornl.gov/wp-content/uploads/2013/02/MPI_MPT-HP.pdf - slide 6 and up