### PR TITLE
Upgrade cudatoolkit to 11.0

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -9,7 +9,7 @@ module swap PrgEnv-cray PrgEnv-gnu
 module load cray-python/3.8.5.0
 module load cray-mpich/7.7.16
 module load Boost/1.70.0-CrayGNU-20.11-python3
-module load cudatoolkit/10.2.89_3.29-7.0.2.1_3.27__g67354b4
+module load cudatoolkit/11.0.2_3.34-7.0.2.1_4.6__g017096a
 module load graphviz/2.44.0
 
 # since gridtools does not play nice with gcc 8.3 we switch to 8.1

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -9,7 +9,7 @@ module swap PrgEnv-cray PrgEnv-gnu
 module load cray-python/3.8.5.0
 module load cray-mpich/7.7.16
 module load Boost/1.70.0-CrayGNU-20.11-python3
-module load cudatoolkit/11.0.2_3.34-7.0.2.1_4.6__g017096a
+module load cudatoolkit/11.2.0_3.36-7.0.2.1_2.2__g3ff9ab1
 module load graphviz/2.44.0
 
 # since gridtools does not play nice with gcc 8.3 we switch to 8.1


### PR DESCRIPTION
This PR updates the `cudatoolkit` version in the daint build environment to 11.0 (the current default).