### PR TITLE
Add gridtools modules

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -14,6 +14,10 @@ module load graphviz/2.44.0
 
 module switch gcc gcc/10.1.0
 
+# load gridtools modules
+module load gridtools/1_1_3
+module load gridtools/2_1_0_b
+
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH


### PR DESCRIPTION
This PR loads the `gridtools` 1.1.3 and 2.1.0 modules that set the `GT_INCLUDE_PATH` and `GT2_INCLUDE_PATH` variables respectively, for gt4py.