### PR TITLE
Changes needed while switching from env.sh to buildenv submodule in pace

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -16,8 +16,8 @@ module load /project/s1053/install/modulefiles/gcloud/303.0.0
 module switch gcc gcc/10.1.0
 
 # load gridtools modules
-module load /project/s1053/install/modulefiles/gcloud/gridtools/1_1_3
-module load /project/s1053/install/modulefiles/gcloud/gridtools/2_1_0
+module load /project/s1053/install/modulefiles/gridtools/1_1_3
+module load /project/s1053/install/modulefiles/gridtools/2_1_0
 
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -16,8 +16,8 @@ module load /project/s1053/install/modulefiles/gcloud/303.0.0
 module switch gcc gcc/10.1.0
 
 # load gridtools modules
-module load gridtools/1_1_3
-module load gridtools/2_1_0
+module load /project/s1053/install/modulefiles/gcloud/gridtools/1_1_3
+module load /project/s1053/install/modulefiles/gcloud/gridtools/2_1_0
 
 NVCC_PATH=$(which nvcc)
 export CUDA_HOME=$(echo $NVCC_PATH | sed -e "s/\/bin\/nvcc//g")

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -11,6 +11,7 @@ module load cray-mpich/7.7.16
 module load Boost/1.70.0-CrayGNU-20.11-python3
 module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
 module load graphviz/2.44.0
+module load /project/s1053/install/modulefiles/gcloud/303.0.0
 
 module switch gcc gcc/10.1.0
 
@@ -25,9 +26,12 @@ export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 # Setup RDMA for GPU. Set PIPE size to 256 (# of messages allowed in flight)
 # Turn as-soon-as-possible transfer (NEMESIS_ASYNC_PROGRESS) on
 export MPICH_RDMA_ENABLED_CUDA=1
+export CRAY_CUDA_MPS=1
 export MPICH_G2G_PIPELINE=256
 export MPICH_NEMESIS_ASYNC_PROGRESS=1
 export MPICH_MAX_THREAD_SAFETY=multiple
 
 # the eve toolchain requires a clang-format executable, we point it to the right place
 export CLANG_FORMAT_EXECUTABLE=/project/s1053/install/venv/vcm_1.0/bin/clang-format
+
+export PYTHONPATH=/project/s1053/install/serialbox/gnu/python:$PYTHONPATH

--- a/machineEnvironment.sh
+++ b/machineEnvironment.sh
@@ -34,7 +34,6 @@ scheduler=""     # none, slurm, pbs, ...
 queue=""         # standard queue to submit jobs to
 nthreads=""      # number of threads to use for parallel builds
 mpilaunch=""     # command to launch an MPI executable (e.g. aprun)
-installdir=""    # directory where libraries are installed
 container_engine=""  # Engine for running containers, e.g. docker, sarus, singuilarity
 python_env=""    # Preferred environment in which to run python code, e.g. virtualenv, container 
 # set default value for useslurm based on whether a submit script exists
@@ -60,7 +59,6 @@ elif [ "`hostname | grep papaya`" != "" ] ; then
     queue="normal"
     nthreads=6
     mpilaunch="mpirun"
-    installdir=/Users/OliverF/Desktop/install
     container_engine="docker"
     python_env="container"
 elif [ "`hostname | grep ubuntu-1804`" != "" ] ; then
@@ -71,7 +69,6 @@ elif [ "`hostname | grep ubuntu-1804`" != "" ] ; then
     queue="normal"
     nthreads=6
     mpilaunch="mpirun"
-    installdir=/tmp
     container_engine="docker"
     python_env="container"
     if [ ! -z "`command -v nvidia-smi`" ] ; then
@@ -86,8 +83,6 @@ elif [ "${CIRCLECI}" == "true" ] ; then
     scheduler="none"
     queue="normal"
     nthreads=6
-    mpilaunch="mpirun"
-    installdir=/tmp
     container_engine="docker"
     python_env="container"
 fi
@@ -98,9 +93,6 @@ test -n "${queue}" || exitError 2002 ${LINENO} "Variable <queue> could not be se
 test -n "${scheduler}" || exitError 2002 ${LINENO} "Variable <scheduler> could not be set (unknown machine `hostname`?)"
 test -n "${nthreads}" || exitError 2003 ${LINENO} "Variable <nthreads> could not be set (unknown machine `hostname`?)"
 test -n "${mpilaunch}" || exitError 2004 ${LINENO} "Variable <mpilaunch> could not be set (unknown machine `hostname`?)"
-test -n "${installdir}" || exitError 2005 ${LINENO} "Variable <installdir> could not be set (unknown machine `hostname`?)"
 test -n "${container_engine}" || exitError 2005 ${LINENO} "Variable <container_engine> could not be set (unknown machine `hostname`?)"
 test -n "${python_env}" || exitError 2005 ${LINENO} "Variable <python_env> could not be set (unknown machine `hostname`?)"
-# export installation directory
-export INSTALL_DIR="${installdir}"
 

--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -27,6 +27,8 @@ showWarning()
 #
 # usage: launch_job script timeout
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 function launch_job {
   local script=$1
   local timeout=$2
@@ -149,7 +151,7 @@ function run_command {
 	local maxsleep=9000
 
 	# test if the slurm script exists, if not, scheduler should not be slurm
-	test -f "${SCRIPT}" || SCRIPT="`dirname $0`/submit.${host}.${scheduler}"
+	test -f "${SCRIPT}" || SCRIPT="${SCRIPT_DIR}/submit.${host}.${scheduler}"
 	test -f "${SCRIPT}" || exitError 1252 ${LINENO} "cannot find script ${SCRIPT}"
 
 	# setup job

--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -27,7 +27,7 @@ showWarning()
 #
 # usage: launch_job script timeout
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCHEDULER_SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 function launch_job {
   local script=$1
@@ -151,7 +151,7 @@ function run_command {
 	local maxsleep=9000
 
 	# test if the slurm script exists, if not, scheduler should not be slurm
-	test -f "${SCRIPT}" || SCRIPT="${SCRIPT_DIR}/submit.${host}.${scheduler}"
+    test -f "${SCRIPT}" || SCRIPT="${SCHEDULER_SCRIPT_DIR}/submit.${host}.${scheduler}"
 	test -f "${SCRIPT}" || exitError 1252 ${LINENO} "cannot find script ${SCRIPT}"
 
 	# setup job

--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -149,8 +149,7 @@ function run_command {
 	local maxsleep=9000
 
 	# test if the slurm script exists, if not, scheduler should not be slurm
-	test -f "${SCRIPT}" || SCRIPT="`dirname $0`/env/submit.${host}.${scheduler}"
-	test -f "${SCRIPT}" || SCRIPT="`dirname $0`/../env/submit.${host}.${scheduler}"
+	test -f "${SCRIPT}" || SCRIPT="`dirname $0`/submit.${host}.${scheduler}"
 	test -f "${SCRIPT}" || exitError 1252 ${LINENO} "cannot find script ${SCRIPT}"
 
 	# setup job


### PR DESCRIPTION
Changes:
- path for gridtools modules is fixed
- set CRAY_CUDA_MPS, needed when interacting with cuda, in env.daint.sh
- set PYTHONPATH to include serialbox in env.daint.sh
- remove `installdir` bash variable from machineEnvironment.sh
- look for scheduler script inside buildenv directory, with no reference to higher directory level