### PR TITLE
Consolidate gpu environment logic in buildenv

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -12,6 +12,7 @@ module load Boost/1.70.0-CrayGNU-20.11-python3
 module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
 module load graphviz/2.44.0
 module load /project/s1053/install/modulefiles/gcloud/303.0.0
+module load nvidia-nsight-systems/2021.1.1.66-6c5c5cb
 
 module switch gcc gcc/10.1.0
 
@@ -27,9 +28,11 @@ export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 # Turn as-soon-as-possible transfer (NEMESIS_ASYNC_PROGRESS) on
 export MPICH_RDMA_ENABLED_CUDA=1
 export CRAY_CUDA_MPS=1
+export CRAY_CUDA_PROXY=0
 export MPICH_G2G_PIPELINE=256
 export MPICH_NEMESIS_ASYNC_PROGRESS=1
 export MPICH_MAX_THREAD_SAFETY=multiple
+export DOCKER_BUILDKIT=1
 
 # the eve toolchain requires a clang-format executable, we point it to the right place
 export CLANG_FORMAT_EXECUTABLE=/project/s1053/install/venv/vcm_1.0/bin/clang-format

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -12,7 +12,6 @@ module load Boost/1.70.0-CrayGNU-20.11-python3
 module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
 module load graphviz/2.44.0
 module load /project/s1053/install/modulefiles/gcloud/303.0.0
-module load nvidia-nsight-systems/2021.1.1.66-6c5c5cb
 
 module switch gcc gcc/10.1.0
 

--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -144,7 +144,6 @@ function launch_job {
 function run_command {
     local CMD=$1
     local NAME=$2
-    local G2G=$3
     local SCRIPT=$4
     
     if [ "${scheduler}" != "none" ] ; then
@@ -160,12 +159,8 @@ function run_command {
 	    NAME="JenkinsJob${BUILD_ID}"
 	fi
 	OUT="${NAME}.out"
-	if [ ${G2G} == "true" ] ; then
-	    G2G_FLAGS="export MPICH_RDMA_ENABLED_CUDA=1\nexport MPICH_G2G_PIPELINE=256"
-	fi
 	# These should get set here
 	sed -i 's|<OUTFILE>|'"${OUT}"'|g' ${SCRIPT}
-	sed -i 's|<G2G>|'"${G2G_FLAGS}"'|g' ${SCRIPT}
 	sed -i 's|<CMD>|'"${CMD}"'|g' ${SCRIPT}
 	sed -i 's|<NAME>|'"${NAME}"'|g' ${SCRIPT}
 	sed -i 's|<NTASKS>|1|g' ${SCRIPT}

--- a/submit.daint.slurm
+++ b/submit.daint.slurm
@@ -15,8 +15,7 @@
 
 set -x
 export OMP_NUM_THREADS=<CPUSPERTASK>
-export CRAY_CUDA_PROXY=0
-<G2G>
+
 <CMD>
 
 ########################################################


### PR DESCRIPTION
## Infrastructure changes:

- G2G is removed as an argument for run_command
- DOCKER_BUILDKIT=1 is set in buildenv, not pace
- PYTHONOPTIMIZE=TRUE is set in run_on_daint.sh, not in the slurm script
- updated pace-util jenkins.sh to match buildenv run_command api

Linked to https://github.com/ai2cm/pace/pull/76