### PR TITLE
use correct argument number for scheduler script

### DIFF
--- a/schedulerTools.sh
+++ b/schedulerTools.sh
@@ -144,7 +144,7 @@ function launch_job {
 function run_command {
     local CMD=$1
     local NAME=$2
-    local SCRIPT=$4
+    local SCRIPT=$3
     
     if [ "${scheduler}" != "none" ] ; then
 	local maxsleep=9000


### PR DESCRIPTION
A bug was introduced by https://github.com/ai2cm/buildenv/pull/32 where an argument was removed but the argument number for the final argument (script filename) was not decremented. This PR fixes that bug.